### PR TITLE
[FIX] set propar semver for react (peerDependencies);

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,21 +15,21 @@
   },
   "peerDependencies": {
     "@flowplayer/player": "^3.2.4",
-    "react": "^17.0.1|^18.2.0"
+    "react": ">= 17.0.1"
   },
   "devDependencies": {
     "@flowplayer/player": "^3.2.4",
-    "@types/react": "^16.9.55",
     "@types/react-dom": "^16.9.9",
+    "@types/react": "^16.9.55",
     "css-loader": "^5.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "style-loader": "^2.0.0",
     "ts-loader": "^9.3.1",
     "typescript": "^4.7.4",
-    "webpack": "^5.73.0",
     "webpack-cli": "^4.10.0",
-    "webpack-dev-server": "4.9.2"
+    "webpack-dev-server": "4.9.2",
+    "webpack": "^5.73.0"
   },
   "dependencies": {},
   "files": [


### PR DESCRIPTION
* Fixed `react` peer dependencies semver to accept version above > `17.0.1`. 
* Ordered dependencies alphabetically (sorry my OCD kicked in 😅)