### PR TITLE
[FEATUER] Expose user interface configuration as a prop;

### DIFF
--- a/demo/demo.tsx
+++ b/demo/demo.tsx
@@ -9,7 +9,7 @@ const DEMO_TOKEN = "eyJraWQiOiJiRmFRNEdUam9lNVEiLCJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1
 
 
 const SOURCES = ["//edge.flowplayer.org/bauhaus.mp4", "//edge.flowplayer.org/functional.mp4"]
-  
+
 const Main = () => {
 
     // Get API handle in an asynchronous manner
@@ -49,34 +49,38 @@ const Main = () => {
         }
     }, [playerApi])
 
-    //if (!Flowplayer) return null
-
-
     return (
-        <div className="container">
-            <h1>Flowplayer React Demo</h1>
-            <div className="row">
-                <div className="column">
-                    <Flowplayer src={demoSrc} token={DEMO_TOKEN} />
-                </div>
-            </div>
-            <div className="row">
-                <div className="column">
-                    Playback state is: { demoPlaybackState }
-                </div>
-            </div>
-            <div className="row">
-                <div className="column">
-                    <h2>API handles</h2>
-                    <button onClick={togglePlay}>Play / pause</button>
-                </div>
-                <div className="column">
-                    <h2>Configuration changes</h2>
-                    <button onClick={toggleSrc}>Toggle source</button>
-                </div>
-            </div>
+      <div className="container">
+        <h1>Flowplayer React Demo</h1>
+        <div className="row">
+          <div className="column">
+            <Flowplayer
+              src={demoSrc}
+              token={DEMO_TOKEN}
+              uiConfig={{
+                usePlay2: false,
+                noFullscreen: false,
+                usePlay3: true,
+                noMute: true
+              }}
+            />
+          </div>
         </div>
-    )
+        <div className="row">
+          <div className="column">Playback state is: {demoPlaybackState}</div>
+        </div>
+        <div className="row">
+          <div className="column">
+            <h2>API handles</h2>
+            <button onClick={togglePlay}>Play / pause</button>
+          </div>
+          <div className="column">
+            <h2>Configuration changes</h2>
+            <button onClick={toggleSrc}>Toggle source</button>
+          </div>
+        </div>
+      </div>
+    );
 }
 
 const container = document.querySelector("#main")

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -1,51 +1,112 @@
+import type { RCConfigUI, RCFlowplayerProps } from "./types/flowplayer-ui";
+
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import flowplayer, { Config } from "@flowplayer/player"
+import flowplayer, { Config } from "@flowplayer/player";
 import FlowplayerComponent from "./flowplayer";
 import { Plugin } from "@flowplayer/player/plugin";
+
+// - Constants
+enum ConfigUI {
+  logoOnRight = 8,
+  noControls = 1024,
+  noDescription = 512,
+  noDuration = 2048,
+  noFullscreen = 1,
+  noHeader = 4096,
+  noMute = 4,
+  noTitle = 256,
+  noVolumeControl = 2,
+  useDragHandle = 16,
+  usePlay2 = 32,
+  usePlay3 = 64,
+  useThinControlBar = 128,
+}
+
+// - Types
+type ConfigUIKey = keyof typeof ConfigUI;
+
+// - Methods
+const convertUIConfigToBitmask = (uiConfig?: Partial<RCConfigUI>): number => {
+  if (!uiConfig) return 0;
+  const uiConfigKeys: [ConfigUIKey] = Object.keys(uiConfig) as [ConfigUIKey];
+
+  const bitmask = uiConfigKeys.reduce((val, key) => {
+    const option = ConfigUI[key];
+    const isActive = uiConfig[key];
+    return isActive ? val | option : val;
+  }, 0);
+
+  return bitmask;
+};
+
+// - Components
+// FIXME: Do we need this wrapper function at all?
+const hookFlowplayer = (
+  ref: React.RefObject<HTMLDivElement>,
+  token: string,
+  opts?: Config,
+  ui?: number,
+) => {
+  return <FlowplayerComponent token={token} ref={ref} {...opts} ui={ui} />;
+};
 
 /**
  * Hook to use Flowplayer API in an async way - tries to solve the chicken/egg problem
  */
-export const useFlowplayer = ({ token } : { token: string }) => {
-    const ref = useRef<HTMLDivElement>(null)
-    
-    // Store flowplayer instances to a state value in order to force re-renders when new instances are available
-    const [flowplayerInstances, setFlowplayerInstances] = useState(flowplayer.instances.slice())
+const useFlowplayerHook = ({ token }: { token: string }) => {
+  const ref = useRef<HTMLDivElement>(null);
 
+  // Store flowplayer instances to a state value in order to force re-renders when new instances are available
+  const [flowplayerInstances, setFlowplayerInstances] = useState(flowplayer.instances.slice());
 
-    const ReactFlowplayerDetectExtension = useMemo(() => class implements Plugin {
+  const ReactFlowplayerDetectExtension = useMemo(
+    () =>
+      class implements Plugin {
         init() {
-            setFlowplayerInstances(flowplayer.instances.slice())
+          setFlowplayerInstances(flowplayer.instances.slice());
         }
-    }, [])
-    
-    // Detect new flowplayer instances to keep up to date
-    useEffect(() => {
-        // If API is already created we don't need the extension
-        if (ref.current && (flowplayer.instances as any[]).some(instance => instance.root == ref.current)) {
-            setFlowplayerInstances(flowplayer.instances.slice())
-            return () => {}
-        }
-        flowplayer(ReactFlowplayerDetectExtension)
-        return () => {
-            (flowplayer.extensions as any[]).filter(ext => ext !== ReactFlowplayerDetectExtension)
-        }
-    }, [])
-    
-    const Flowplayer = useMemo(() => {
-        if (!token) return null
-        return hookFlowplayer(ref, token)
-    }, [token, ref])
-    
-    return useMemo(() => {
-        if (!Flowplayer) return { Flowplayer: (opts: Config) => null, api: null }
-        return {
-            Flowplayer,
-            api: ref.current ? flowplayer(ref.current) : null
-        }
-    }, [Flowplayer, flowplayerInstances])
-}
+      },
+    [],
+  );
 
-const hookFlowplayer = (ref: React.RefObject<HTMLDivElement>, token: string) => {
-    return (opts: Config) => <FlowplayerComponent token={token} ref ={ref} {...opts} />
-}
+  // Detect new flowplayer instances to keep up to date
+  useEffect(() => {
+    // If API is already created we don't need the extension
+    if (
+      ref.current &&
+      (flowplayer.instances as any[]).some((instance) => instance.root == ref.current)
+    ) {
+      setFlowplayerInstances(flowplayer.instances.slice());
+      return () => {};
+    }
+    flowplayer(ReactFlowplayerDetectExtension);
+    return () => {
+      (flowplayer.extensions as any[]).filter((ext) => ext !== ReactFlowplayerDetectExtension);
+    };
+  }, []);
+
+  /// Wrapped Flowplayer comp so that we can expose public props
+  const RCFlowplayer = ({ uiConfig, ...opts }: RCFlowplayerProps) => {
+    if (!token) return null;
+
+    const Flowplayer = useMemo(() => {
+      if (!token) return null;
+      return hookFlowplayer(ref, token, opts, convertUIConfigToBitmask(uiConfig));
+    }, [token, ref]);
+
+    return Flowplayer;
+  };
+
+  return useMemo(() => {
+    if (!RCFlowplayer) return { Flowplayer: (opts: Config) => null, api: null };
+    return {
+      Flowplayer: RCFlowplayer,
+      api: ref.current ? flowplayer(ref.current) : null,
+    };
+  }, [RCFlowplayer, flowplayerInstances]);
+};
+
+// - Exports
+export const useFlowplayer = useFlowplayerHook;
+export type FlowplayerProps = RCFlowplayerProps;
+export type FlowplayerConfigUI = RCConfigUI

--- a/src/types/flowplayer-ui.d.ts
+++ b/src/types/flowplayer-ui.d.ts
@@ -1,0 +1,19 @@
+import type { Config } from "@flowplayer/player";
+
+export type RCConfigUI = {
+  logoOnRight: boolean;
+  noControls: boolean;
+  noDescription: boolean;
+  noDuration: boolean;
+  noFullscreen: boolean;
+  noHeader: boolean;
+  noMute: boolean;
+  noTitle: boolean;
+  noVolumeControl: boolean;
+  useDragHandle: boolean;
+  usePlay2: boolean;
+  usePlay3: boolean;
+  useThinControlBar: boolean;
+};
+
+export type RCFlowplayerProps = { uiConfig?: Partial<RCConfigUI> } & Config;


### PR DESCRIPTION
This PR adds support for [User Interface Configuration](https://docs.flowplayer.com/player/configuration#user-interface-configuration) for the Flowplayer component. It hides the complexity of using bitmask and instead allows the user to set the `uiConfig` prop with a object syntax.

**Example:**
```javascript
<Flowplayer
        src={demoSrc}
        token={DEMO_TOKEN}
        uiConfig={{
              noFullscreen: false,
              usePlay3: true,
              noMute: true
         }}
/>
```

**Disclaimer:** 
I did not know where to put the global types so I created a new directory called `types` and added them to `flowplayer-ui.d.ts`.
