### PR TITLE
refactor: fa-734 automate npm publish DRY RUN

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,8 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-      # - name: Publish to NPMJS
-      #   uses: JS-DevTools/npm-publish@v3
-      #   with:
-      #     token: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to NPMJS
+        uses: JS-DevTools/npm-publish@v3
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          dry-run: true


### PR DESCRIPTION
adds a step to deployment action to publish the package on npmjs.com

this has the dry run flag to test the publish step and prevent duplicate packages from being published