### PR TITLE
chore: [FA-734] remove dry run flag for NPM package publishing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,4 +47,3 @@ jobs:
         uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}
-          dry-run: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowplayer/react-flowplayer",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Flowplayer React Component",
   "main": "lib/index.js",
   "repository": "git@github.com:flowplayer/react-flowplayer.git",


### PR DESCRIPTION
removes dry-run flag for gihtub action
bumps package version to trigger a publish to npmjs